### PR TITLE
Set the baudrate to 115200

### DIFF
--- a/s2m/micro_bit_scripts/s2mb.py
+++ b/s2m/micro_bit_scripts/s2mb.py
@@ -35,6 +35,9 @@ from microbit import *
 #   t - digital write for the specified pin and value (0 or 1)
 #   v - get version string
 
+# explicitly assign the same baudrate on both communicating devices
+uart.init(115200)
+
 while True:
     data = uart.readline()
     sleep(8)


### PR DESCRIPTION
Explicitly assign the same baudrate on both communicating devices

Without setting the same baudrate on both sides correctly, the `s2m` program cannot detect the UART device. According to the official documents, the default baudrate is `9600`.
http://microbit-micropython.readthedocs.io/en/latest/uart.html