### PR TITLE
Add a script to auto install and launch s2m under Windows

### DIFF
--- a/helper/linux_s2m.sh
+++ b/helper/linux_s2m.sh
@@ -13,7 +13,7 @@ s2m_base="${USER_SITE}/s2m"
 if [ ! -f "$s2m" ]; then
 	pip install --user --upgrade s2m
 	pip install --user --upgrade uflash
-	${uflash} "${s2m_mb}"
+	"${uflash}" "${s2m_mb}"
 fi
 
 # scratch2 path
@@ -26,8 +26,8 @@ if [ -f "/usr/local/bin/scratch2" ]; then
 fi
 
 if [ -f "/opt/Scratch 2/bin/Scratch 2" ]; then
-	scratch2="/opt/Scratch 2/bin/Scratch 2"
+	scratch2='/opt/Scratch\ 2/bin/Scratch\ 2'
 fi
 
 # launch s2m
-${s2m} -b "${s2m_base}" -s "${scratch2}"
+"${s2m}" -b "${s2m_base}" -s "${scratch2}"

--- a/helper/linux_s2m.sh
+++ b/helper/linux_s2m.sh
@@ -6,7 +6,7 @@ USER_SITE=$( python -m site | grep USER_SITE | grep -oP "(?<=')[^']+(?=')" )
 
 s2m="${USER_BASE}/bin/s2m"
 uflash="${USER_BASE}/bin/uflash"
-s2m_mb="${USER_SITE}/s2m/micro_bit_scripts/2mb_min.py"
+s2m_mb="${USER_SITE}/s2m/micro_bit_scripts/s2mb_min.py"
 s2m_base="${USER_SITE}/s2m"
 
 # install and upload firmware

--- a/helper/linux_s2m.sh
+++ b/helper/linux_s2m.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# python path
+USER_BASE=$( python -m site | grep USER_BASE | grep -oP "(?<=')[^']+(?=')" )
+USER_SITE=$( python -m site | grep USER_SITE | grep -oP "(?<=')[^']+(?=')" )
+
+s2m="${USER_BASE}/bin/s2m"
+uflash="${USER_BASE}/bin/uflash"
+s2m_mb="${USER_SITE}/s2m/micro_bit_scripts/2mb_min.py"
+s2m_base="${USER_SITE}/s2m"
+
+# install and upload firmware
+if [ ! -f "$s2m" ]; then
+	pip install --user --upgrade s2m
+	pip install --user --upgrade uflash
+	${uflash} "${s2m_mb}"
+fi
+
+# scratch2 path
+if [ -f "/usr/bin/scratch2" ]; then
+	scratch2="/usr/bin/scratch2"
+fi
+
+if [ -f "/usr/local/bin/scratch2" ]; then
+	scratch2="/usr/local/bin/scratch2"
+fi
+
+if [ -f "/opt/Scratch 2/bin/Scratch 2" ]; then
+	scratch2="/opt/Scratch 2/bin/Scratch 2"
+fi
+
+# launch s2m
+${s2m} -b "${s2m_base}" -s "${scratch2}"

--- a/helper/win_py3_s2m.cmd
+++ b/helper/win_py3_s2m.cmd
@@ -45,7 +45,7 @@ IF EXIST %s2m% (
     @ECHO **** Found installed s2m at %s2m% ****
 ) ELSE (
     @ECHO **** s2m not found! Install s2m and uflash from PyPI. ****
-    %py3_base%\Scripts\pip.exe install --user --upgrade s2m==2.4
+    %py3_base%\Scripts\pip.exe install --user --upgrade s2m
     %py3_base%\Scripts\pip.exe install --user --upgrade uflash
     
     @ECHO **** Upload the s2m program to your Micro:Bit ****
@@ -54,10 +54,10 @@ IF EXIST %s2m% (
 
 REM Auto launch s2m and Scratch2
 IF EXIST  "%ProgramFiles(x86)%\Scratch 2\Scratch 2.exe" (
-    %s2m% -l tw -b %s2m_base% -s "%ProgramFiles(x86)%\Scratch 2\Scratch 2.exe"
+    %s2m% -b %s2m_base% -s "%ProgramFiles(x86)%\Scratch 2\Scratch 2.exe"
 )
 ELSE (
-    %s2m% -l tw -b %s2m_base% -s "%ProgramFiles%\Scratch 2\Scratch 2.exe"
+    %s2m% -b %s2m_base% -s "%ProgramFiles%\Scratch 2\Scratch 2.exe"
 )
 
 ENDLOCAL

--- a/helper/win_py3_s2m.cmd
+++ b/helper/win_py3_s2m.cmd
@@ -1,0 +1,63 @@
+@ECHO OFF
+
+SETLOCAL
+
+REM Determine the version of installed Python3 (32-bit or 64-bit)
+SET py3_list=33 34 35 36
+SET py3_temp=%localappdata%\Programs\Python
+SET py3_ver=32-32
+SET py3_base=
+SET py3_modules=%appdata%\Python
+
+FOR %%v IN (%py3_list%) DO (
+    IF EXIST %py3_temp%\Python%%v-32\python.exe (
+        SET py3_base=%py3_temp%\Python%%v-32
+        SET py3_ver=%%v-32
+    )
+)
+
+FOR %%v IN (%py3_list%) DO (
+    IF EXIST %py3_temp%\Python%%v\python.exe (
+        SET py3_base=%py3_temp%\Python%%v
+        SET py3_ver=%%v
+    )
+)
+
+REM Chech if Python3 is installed
+IF DEFINED py3_base (
+    REM
+) ELSE (
+    @ECHO **** Python3 not found! Please install the latest versions of Python3. ****
+    START "" https://www.python.org/downloads/
+    EXIT /B 0
+)
+
+@ECHO **** Found installed Python3 (%py3_ver%) at %py3_base% ****
+
+REM Check if s2m is installed
+SET s2m=%py3_modules%\Python%py3_ver%\Scripts\s2m.exe
+SET s2m_base=%py3_modules%\Python%py3_ver%\site-packages\s2m
+
+SET uflash=%py3_modules%\Python%py3_ver%\Scripts\uflash.exe
+SET s2m_mb=%py3_modules%\Python%py3_ver%\site-packages\s2m\micro_bit_scripts\s2mb_min.py
+
+IF EXIST %s2m% (
+    @ECHO **** Found installed s2m at %s2m% ****
+) ELSE (
+    @ECHO **** s2m not found! Install s2m and uflash from PyPI. ****
+    %py3_base%\Scripts\pip.exe install --user --upgrade s2m==2.4
+    %py3_base%\Scripts\pip.exe install --user --upgrade uflash
+    
+    @ECHO **** Upload the s2m program to your Micro:Bit ****
+    %uflash% %s2m_mb%
+)
+
+REM Auto launch s2m and Scratch2
+IF EXIST  "%ProgramFiles(x86)%\Scratch 2\Scratch 2.exe" (
+    %s2m% -l tw -b %s2m_base% -s "%ProgramFiles(x86)%\Scratch 2\Scratch 2.exe"
+)
+ELSE (
+    %s2m% -l tw -b %s2m_base% -s "%ProgramFiles%\Scratch 2\Scratch 2.exe"
+)
+
+ENDLOCAL


### PR DESCRIPTION
It is difficult to launch s2m program without the correct path name.
I created a simple script to launch s2m and do something automatically.
Maybe it would be helpful for one-click installation.

1.  determine the the version of installed Python3 (32-bit or 64-bit)
2. check if Python3 is installed
3. auto install s2m and [uflash](https://github.com/ntoll/uflash)
4. upload `s2mb_min.py` to Micro:Bit using `uflash`
5. launch s2m and Scratch2